### PR TITLE
Edit user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,15 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def update
+    if current_user != nil
+      current_user.update(user_params)
+      redirect_to root_path
+    else
+      render file: "/public/404"
+    end
+  end
+
 
   private
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,12 @@
+<a class="table">
+<%= form_for @user do |f| %>
+
+  <%= f.label :first_name %>
+  <%= f.text_field :first_name %>
+
+  <%= f.label :last_name%>
+  <%= f.text_field :last_name %>
+
+  <%= f.submit "Submit" %>
+<% end %>
+</a>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,8 @@
 <%= link_to "Register Account", new_user_path %>
 <% if current_user %>
   <%= link_to "Logout", logout_path %>
+  <h2>Hello <%= "#{current_user.first_name} #{current_user.last_name}"%> </h2>
+  <h3>Signed in under: <%= "#{current_user.email}" %>  </h3>
 <% else %>
   <%= link_to "Login", login_path %>
 <% end %>

--- a/spec/features/user_can_edit_account_spec.rb
+++ b/spec/features/user_can_edit_account_spec.rb
@@ -9,14 +9,12 @@ feature 'Edit Account and Business Card' do
     expect(page).to have_content("Rick Deckard")
     expect(page).to have_content("blade@runner.com")
 
-    visit '/edit-profile'
-
-    # expect page to have a form??
+    visit edit_user_path(user)
 
     fill_in "user[first_name]", with: "Richard"
     fill_in "user[last_name]", with: "Deckard"
 
-    click_on "Submit Changes"
+    click_on "Submit"
 
     expect(current_path).to eq('/')
     expect(page).to have_content("Richard Deckard")

--- a/spec/features/user_can_edit_account_spec.rb
+++ b/spec/features/user_can_edit_account_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 feature 'Edit Account and Business Card' do
-  xscenario "a user visits the edit account page and edits their account" do
+  scenario "a user visits the edit account page and edits their account" do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
     visit '/'
     expect(page).to have_content("Rick Deckard")
     expect(page).to have_content("blade@runner.com")


### PR DESCRIPTION
User is now able to edit their first and last name. Since two factor reset is on the roadmap I do not want to allow the user to edit their password using this same feature. Additionally users should not be able to change their email address since it is their unique identifier in the database (aside from id of course). 